### PR TITLE
Use UiState-managed fields for training program forms

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -59,6 +59,19 @@
     <string name="actions_message">Visualiza y gestiona tus acciones registradas</string>
     <string name="no_actions">Aún no hay acciones registradas</string>
 
+    <!-- Programas de formación -->
+    <string name="training_programs_title">Programas de Formación</string>
+    <string name="add_training_program_title">Agregar Programa de Formación</string>
+    <string name="training_program_detail_title">Detalle del Programa de Formación</string>
+    <string name="name_label">Nombre</string>
+    <string name="code_label">Código</string>
+    <string name="start_date_label">Fecha de inicio</string>
+    <string name="end_date_label">Fecha de fin</string>
+    <string name="schedule_label">Horario</string>
+    <string name="student_id_label">ID del estudiante</string>
+    <string name="button_add_student">Agregar estudiante</string>
+    <string name="button_delete">Eliminar</string>
+
     <!-- Informes -->
     <string name="reports_title">Informes</string>
     <string name="reports_message">Visualiza y gestiona tus informes generados</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -61,6 +61,19 @@
     <string name="actions_message">View and manage your recorded actions</string>
     <string name="no_actions">No actions recorded yet</string>
 
+    <!-- Training Programs -->
+    <string name="training_programs_title">Training Programs</string>
+    <string name="add_training_program_title">Add Training Program</string>
+    <string name="training_program_detail_title">Training Program Detail</string>
+    <string name="name_label">Name</string>
+    <string name="code_label">Code</string>
+    <string name="start_date_label">Start Date</string>
+    <string name="end_date_label">End Date</string>
+    <string name="schedule_label">Schedule</string>
+    <string name="student_id_label">Student ID</string>
+    <string name="button_add_student">Add Student</string>
+    <string name="button_delete">Delete</string>
+
     <!-- Reports -->
     <string name="reports_title">Reports</string>
     <string name="reports_message">View and manage your generated reports</string>

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/training_programs/TrainingProgramsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/training_programs/TrainingProgramsRepository.kt
@@ -1,24 +1,28 @@
 package com.juanpablo0612.sigat.data.training_programs
 
-import com.juanpablo0612.sigat.data.training_programs.model.TrainingProgramModel
 import com.juanpablo0612.sigat.data.training_programs.remote.TrainingProgramsRemoteDataSource
+import com.juanpablo0612.sigat.domain.model.TrainingProgram
+import com.juanpablo0612.sigat.domain.model.toDomain
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class TrainingProgramsRepository(private val remoteDataSource: TrainingProgramsRemoteDataSource) {
-    fun getTrainingProgramsByTeacherId(teacherId: String): Flow<List<TrainingProgramModel>> {
-        return remoteDataSource.getTrainingProgramsByTeacherId(teacherId)
+    fun getTrainingProgramsByTeacherId(teacherId: String): Flow<List<TrainingProgram>> {
+        return remoteDataSource.getTrainingProgramsByTeacherId(teacherId).map { list ->
+            list.map { it.toDomain() }
+        }
     }
 
-    suspend fun getTrainingProgram(id: String): TrainingProgramModel? {
-        return remoteDataSource.getTrainingProgram(id)
+    suspend fun getTrainingProgram(id: String): TrainingProgram? {
+        return remoteDataSource.getTrainingProgram(id)?.toDomain()
     }
 
-    suspend fun createTrainingProgram(trainingProgram: TrainingProgramModel) {
-        remoteDataSource.createTrainingProgram(trainingProgram)
+    suspend fun createTrainingProgram(trainingProgram: TrainingProgram) {
+        remoteDataSource.createTrainingProgram(trainingProgram.toModel())
     }
 
-    suspend fun updateTrainingProgram(trainingProgram: TrainingProgramModel) {
-        remoteDataSource.updateTrainingProgram(trainingProgram)
+    suspend fun updateTrainingProgram(trainingProgram: TrainingProgram) {
+        remoteDataSource.updateTrainingProgram(trainingProgram.toModel())
     }
 
     suspend fun deleteTrainingProgram(id: String) {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/training_programs/model/TrainingProgramModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/training_programs/model/TrainingProgramModel.kt
@@ -1,12 +1,15 @@
 package com.juanpablo0612.sigat.data.training_programs.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class TrainingProgramModel(
-    val id: String,
-    val name: String,
-    val code: Int,
-    val startDate: Long,
-    val endDate: Long,
-    val schedule: String,
-    val teacherUserId: String,
-    val students: List<String>
+    val id: String = "",
+    val name: String = "",
+    val code: Int = 0,
+    val startDate: Long = 0L,
+    val endDate: Long = 0L,
+    val schedule: String = "",
+    val teacherUserId: String = "",
+    val students: List<String> = emptyList()
 )

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/di.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/di.kt
@@ -13,6 +13,8 @@ import com.juanpablo0612.sigat.data.reports.local.ReportsLocalDataSource
 import com.juanpablo0612.sigat.data.reports.local.ReportsLocalDataSourceImpl
 import com.juanpablo0612.sigat.data.roles.RolesRepository
 import com.juanpablo0612.sigat.data.roles.remote.RolesRemoteDataSource
+import com.juanpablo0612.sigat.data.training_programs.TrainingProgramsRepository
+import com.juanpablo0612.sigat.data.training_programs.remote.TrainingProgramsRemoteDataSource
 import com.juanpablo0612.sigat.data.users.UsersRepository
 import com.juanpablo0612.sigat.data.users.remote.UsersRemoteDataSource
 import com.juanpablo0612.sigat.domain.usecase.auth.ValidateEmailUseCase
@@ -27,6 +29,9 @@ import com.juanpablo0612.sigat.state_holders.UserStateHolderImpl
 import com.juanpablo0612.sigat.ui.actions.action_list.ActionListViewModel
 import com.juanpablo0612.sigat.ui.actions.add_action.AddActionViewModel
 import com.juanpablo0612.sigat.ui.admin.manage_roles.ManageRolesViewModel
+import com.juanpablo0612.sigat.ui.training_programs.add.AddTrainingProgramViewModel
+import com.juanpablo0612.sigat.ui.training_programs.detail.TrainingProgramDetailViewModel
+import com.juanpablo0612.sigat.ui.training_programs.list.TrainingProgramListViewModel
 import com.juanpablo0612.sigat.ui.auth.login.LoginViewModel
 import com.juanpablo0612.sigat.ui.auth.register.RegisterViewModel
 import com.juanpablo0612.sigat.ui.home.HomeViewModel
@@ -58,6 +63,9 @@ val viewModelModule = module {
     viewModelOf(::ManageRolesViewModel)
     viewModelOf(::GenerateReportViewModel)
     viewModelOf(::ActionListViewModel)
+    viewModelOf(::TrainingProgramListViewModel)
+    viewModelOf(::AddTrainingProgramViewModel)
+    viewModelOf(::TrainingProgramDetailViewModel)
 }
 
 val domainModule = module {
@@ -86,6 +94,8 @@ val dataModule = module {
     singleOf(::ObligationsRepository)
     single<ReportsLocalDataSource> { ReportsLocalDataSourceImpl() }
     singleOf(::ReportsRepository)
+    singleOf(::TrainingProgramsRemoteDataSource)
+    singleOf(::TrainingProgramsRepository)
 }
 
 fun initKoin(koinAppDeclaration: KoinAppDeclaration? = null) {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/TrainingProgram.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/TrainingProgram.kt
@@ -1,0 +1,39 @@
+package com.juanpablo0612.sigat.domain.model
+
+import com.juanpablo0612.sigat.data.training_programs.model.TrainingProgramModel
+
+/**
+ * Domain model representing a training program.
+ */
+data class TrainingProgram(
+    val id: String = "",
+    val name: String = "",
+    val code: Int = 0,
+    val startDate: Long = 0L,
+    val endDate: Long = 0L,
+    val schedule: String = "",
+    val teacherUserId: String = "",
+    val students: List<String> = emptyList()
+) {
+    fun toModel() = TrainingProgramModel(
+        id = id,
+        name = name,
+        code = code,
+        startDate = startDate,
+        endDate = endDate,
+        schedule = schedule,
+        teacherUserId = teacherUserId,
+        students = students
+    )
+}
+
+fun TrainingProgramModel.toDomain() = TrainingProgram(
+    id = id,
+    name = name,
+    code = code,
+    startDate = startDate,
+    endDate = endDate,
+    schedule = schedule,
+    teacherUserId = teacherUserId,
+    students = students
+)

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/home/HomeNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/home/HomeNavigation.kt
@@ -2,6 +2,7 @@ package com.juanpablo0612.sigat.ui.home
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Report
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -17,6 +18,7 @@ enum class HomeDestinations(
     val label: StringResource,
     val icon: ImageVector
 ) {
+    TrainingPrograms(Res.string.training_programs_title, Icons.Default.List),
     Actions(Res.string.actions_title, Icons.Default.History),
     Reports(Res.string.reports_title, Icons.Default.Report),
     ManageRoles(Res.string.manage_roles_title, Icons.Default.People)
@@ -29,7 +31,7 @@ fun getScreenListForRole(role: Role): List<HomeDestinations> {
         )
 
         RoleType.TEACHER -> {
-            listOf(HomeDestinations.Actions, HomeDestinations.Reports)
+            listOf(HomeDestinations.TrainingPrograms, HomeDestinations.Actions, HomeDestinations.Reports)
         }
 
         else -> {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.juanpablo0612.sigat.ui.actions.action_list.ActionListScreen
 import com.juanpablo0612.sigat.ui.admin.manage_roles.ManageRolesScreen
+import com.juanpablo0612.sigat.ui.training_programs.list.TrainingProgramListScreen
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -19,6 +20,8 @@ fun HomeScreen(
     viewModel: HomeViewModel = koinViewModel(),
     windowSize: WindowSizeClass,
     onNavigateToAddAction: () -> Unit,
+    onNavigateToAddTrainingProgram: () -> Unit,
+    onNavigateToTrainingProgramDetail: (String) -> Unit,
     onLogout: () -> Unit
 ) {
     val uiState = viewModel.uiState
@@ -55,6 +58,14 @@ fun HomeScreen(
             when (currentDestination) {
                 HomeDestinations.ManageRoles -> {
                     ManageRolesScreen(windowSize = windowSize)
+                }
+
+                HomeDestinations.TrainingPrograms -> {
+                    TrainingProgramListScreen(
+                        windowSize = windowSize,
+                        onAddProgramClick = onNavigateToAddTrainingProgram,
+                        onProgramClick = onNavigateToTrainingProgramDetail
+                    )
                 }
 
                 HomeDestinations.Actions -> {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/AppNavigation.kt
@@ -12,12 +12,15 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
 import com.juanpablo0612.sigat.ui.actions.add_action.AddActionScreen
 import com.juanpablo0612.sigat.ui.auth.login.LoginScreen
 import com.juanpablo0612.sigat.ui.auth.register.RegisterScreen
 import com.juanpablo0612.sigat.ui.components.LoadingContent
 import com.juanpablo0612.sigat.ui.home.HomeScreen
 import com.juanpablo0612.sigat.ui.reports.generate_report.GenerateReportScreen
+import com.juanpablo0612.sigat.ui.training_programs.add.AddTrainingProgramScreen
+import com.juanpablo0612.sigat.ui.training_programs.detail.TrainingProgramDetailScreen
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -61,6 +64,8 @@ fun AppNavigation(
             addHomeScreen(navController = navController, windowSize = windowSize)
             addAddActionScreen(navController = navController, windowSize = windowSize)
             addGenerateReportScreen(navController = navController, windowSize = windowSize)
+            addAddTrainingProgramScreen(navController = navController, windowSize = windowSize)
+            addTrainingProgramDetailScreen(navController = navController, windowSize = windowSize)
         }
     } else {
         LoadingContent(modifier = Modifier.fillMaxSize())
@@ -108,6 +113,12 @@ fun NavGraphBuilder.addHomeScreen(navController: NavController, windowSize: Wind
             onNavigateToAddAction = {
                 navController.navigate(Screen.AddAction)
             },
+            onNavigateToAddTrainingProgram = {
+                navController.navigate(Screen.AddTrainingProgram)
+            },
+            onNavigateToTrainingProgramDetail = { id ->
+                navController.navigate(Screen.TrainingProgramDetail(id))
+            },
             onLogout = {
                 navController.navigate(Screen.Login) {
                     popUpTo(Screen.Home) {
@@ -136,5 +147,31 @@ fun NavGraphBuilder.addGenerateReportScreen(
 ) {
     composable<Screen.GenerateReport> {
         GenerateReportScreen()
+    }
+}
+
+fun NavGraphBuilder.addAddTrainingProgramScreen(
+    navController: NavController,
+    windowSize: WindowSizeClass
+) {
+    composable<Screen.AddTrainingProgram> {
+        AddTrainingProgramScreen(
+            windowSize = windowSize,
+            onNavigateBack = { navController.navigateUp() }
+        )
+    }
+}
+
+fun NavGraphBuilder.addTrainingProgramDetailScreen(
+    navController: NavController,
+    windowSize: WindowSizeClass
+) {
+    composable<Screen.TrainingProgramDetail> { backStackEntry ->
+        val args = backStackEntry.toRoute<Screen.TrainingProgramDetail>()
+        TrainingProgramDetailScreen(
+            programId = args.programId,
+            windowSize = windowSize,
+            onNavigateBack = { navController.navigateUp() }
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/Screens.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/Screens.kt
@@ -23,4 +23,10 @@ sealed class Screen {
 
     @Serializable
     object GenerateReport: Screen()
+
+    @Serializable
+    object AddTrainingProgram: Screen()
+
+    @Serializable
+    data class TrainingProgramDetail(val programId: String): Screen()
 }

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
@@ -1,0 +1,101 @@
+package com.juanpablo0612.sigat.ui.training_programs.add
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import sigat.composeapp.generated.resources.Res
+import sigat.composeapp.generated.resources.add_training_program_title
+import sigat.composeapp.generated.resources.button_save
+import sigat.composeapp.generated.resources.code_label
+import sigat.composeapp.generated.resources.end_date_label
+import sigat.composeapp.generated.resources.name_label
+import sigat.composeapp.generated.resources.schedule_label
+import sigat.composeapp.generated.resources.start_date_label
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddTrainingProgramScreen(
+    viewModel: AddTrainingProgramViewModel = koinViewModel(),
+    windowSize: WindowSizeClass,
+    onNavigateBack: () -> Unit
+) {
+    val uiState = viewModel.uiState
+    if (uiState.saved) {
+        LaunchedEffect(Unit) { onNavigateBack() }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.add_training_program_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier.padding(innerPadding).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            TextField(
+                value = uiState.name,
+                onValueChange = viewModel::onNameChange,
+                label = { Text(stringResource(Res.string.name_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                isError = !uiState.validName
+            )
+            TextField(
+                value = uiState.code,
+                onValueChange = viewModel::onCodeChange,
+                label = { Text(stringResource(Res.string.code_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                isError = !uiState.validCode
+            )
+            TextField(
+                value = uiState.startDate,
+                onValueChange = viewModel::onStartDateChange,
+                label = { Text(stringResource(Res.string.start_date_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                isError = !uiState.validStartDate
+            )
+            TextField(
+                value = uiState.endDate,
+                onValueChange = viewModel::onEndDateChange,
+                label = { Text(stringResource(Res.string.end_date_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                isError = !uiState.validEndDate
+            )
+            TextField(
+                value = uiState.schedule,
+                onValueChange = viewModel::onScheduleChange,
+                label = { Text(stringResource(Res.string.schedule_label)) },
+                modifier = Modifier.fillMaxWidth(),
+                isError = !uiState.validSchedule
+            )
+            Button(onClick = { viewModel.addTrainingProgram() }, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(Res.string.button_save))
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramViewModel.kt
@@ -1,0 +1,105 @@
+package com.juanpablo0612.sigat.ui.training_programs.add
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.juanpablo0612.sigat.data.training_programs.TrainingProgramsRepository
+import com.juanpablo0612.sigat.domain.model.TrainingProgram
+import com.juanpablo0612.sigat.state_holders.UserStateHolder
+import kotlinx.coroutines.launch
+
+class AddTrainingProgramViewModel(
+    private val repository: TrainingProgramsRepository,
+    private val userStateHolder: UserStateHolder,
+) : ViewModel() {
+    var uiState by mutableStateOf(AddTrainingProgramUiState())
+        private set
+
+    fun onNameChange(newName: String) {
+        uiState = uiState.copy(name = newName, validName = newName.isNotBlank())
+    }
+
+    fun onCodeChange(newCode: String) {
+        uiState = uiState.copy(code = newCode, validCode = newCode.toIntOrNull() != null)
+    }
+
+    fun onStartDateChange(newStartDate: String) {
+        val valid = newStartDate.toLongOrNull() != null
+        val validEnd = uiState.endDate.toLongOrNull()?.let { end ->
+            newStartDate.toLongOrNull()?.let { start -> start <= end } ?: false
+        } ?: true
+        uiState = uiState.copy(startDate = newStartDate, validStartDate = valid && validEnd)
+        if (!validEnd) {
+            uiState = uiState.copy(validEndDate = false)
+        }
+    }
+
+    fun onEndDateChange(newEndDate: String) {
+        val endLong = newEndDate.toLongOrNull()
+        val startLong = uiState.startDate.toLongOrNull()
+        val valid = endLong != null && (startLong == null || startLong <= endLong)
+        uiState = uiState.copy(endDate = newEndDate, validEndDate = valid)
+    }
+
+    fun onScheduleChange(newSchedule: String) {
+        uiState = uiState.copy(schedule = newSchedule, validSchedule = newSchedule.isNotBlank())
+    }
+
+    private fun validateFields() {
+        onNameChange(uiState.name)
+        onCodeChange(uiState.code)
+        onStartDateChange(uiState.startDate)
+        onEndDateChange(uiState.endDate)
+        onScheduleChange(uiState.schedule)
+    }
+
+    private fun allFieldsValid(): Boolean {
+        return uiState.validName && uiState.validCode && uiState.validStartDate && uiState.validEndDate && uiState.validSchedule
+    }
+
+    fun addTrainingProgram() {
+        viewModelScope.launch {
+            validateFields()
+
+            if (!allFieldsValid()) return@launch
+
+            uiState = uiState.copy(loading = true)
+            try {
+                val teacherId = userStateHolder.userState.user?.uid ?: return@launch
+                repository.createTrainingProgram(
+                    TrainingProgram(
+                        name = uiState.name,
+                        code = uiState.code.toInt(),
+                        startDate = uiState.startDate.toLong(),
+                        endDate = uiState.endDate.toLong(),
+                        schedule = uiState.schedule,
+                        teacherUserId = teacherId
+                    )
+                )
+                uiState = uiState.copy(saved = true)
+            } catch (e: Exception) {
+                uiState = uiState.copy(exception = e)
+            } finally {
+                uiState = uiState.copy(loading = false)
+            }
+        }
+    }
+}
+
+data class AddTrainingProgramUiState(
+    val name: String = "",
+    val validName: Boolean = true,
+    val code: String = "",
+    val validCode: Boolean = true,
+    val startDate: String = "",
+    val validStartDate: Boolean = true,
+    val endDate: String = "",
+    val validEndDate: Boolean = true,
+    val schedule: String = "",
+    val validSchedule: Boolean = true,
+    val loading: Boolean = false,
+    val exception: Exception? = null,
+    val saved: Boolean = false
+)

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
@@ -1,0 +1,152 @@
+package com.juanpablo0612.sigat.ui.training_programs.detail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.juanpablo0612.sigat.ui.components.LoadingContent
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import sigat.composeapp.generated.resources.Res
+import sigat.composeapp.generated.resources.button_add_student
+import sigat.composeapp.generated.resources.button_delete
+import sigat.composeapp.generated.resources.button_save
+import sigat.composeapp.generated.resources.code_label
+import sigat.composeapp.generated.resources.end_date_label
+import sigat.composeapp.generated.resources.name_label
+import sigat.composeapp.generated.resources.schedule_label
+import sigat.composeapp.generated.resources.start_date_label
+import sigat.composeapp.generated.resources.student_id_label
+import sigat.composeapp.generated.resources.training_program_detail_title
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TrainingProgramDetailScreen(
+    programId: String,
+    viewModel: TrainingProgramDetailViewModel = koinViewModel(),
+    windowSize: WindowSizeClass,
+    onNavigateBack: () -> Unit
+) {
+    val uiState = viewModel.uiState
+    LaunchedEffect(programId) { viewModel.loadTrainingProgram(programId) }
+    if (uiState.finished) {
+        LaunchedEffect(Unit) { onNavigateBack() }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.training_program_detail_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        if (!uiState.loading && uiState.id.isNotEmpty()) {
+            Column(
+                modifier = Modifier.padding(innerPadding).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TextField(
+                    value = uiState.name,
+                    onValueChange = viewModel::onNameChange,
+                    label = { Text(stringResource(Res.string.name_label)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = !uiState.validName
+                )
+                TextField(
+                    value = uiState.code,
+                    onValueChange = viewModel::onCodeChange,
+                    label = { Text(stringResource(Res.string.code_label)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = !uiState.validCode
+                )
+                TextField(
+                    value = uiState.startDate,
+                    onValueChange = viewModel::onStartDateChange,
+                    label = { Text(stringResource(Res.string.start_date_label)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = !uiState.validStartDate
+                )
+                TextField(
+                    value = uiState.endDate,
+                    onValueChange = viewModel::onEndDateChange,
+                    label = { Text(stringResource(Res.string.end_date_label)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = !uiState.validEndDate
+                )
+                TextField(
+                    value = uiState.schedule,
+                    onValueChange = viewModel::onScheduleChange,
+                    label = { Text(stringResource(Res.string.schedule_label)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = !uiState.validSchedule
+                )
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    TextField(
+                        value = uiState.newStudentId,
+                        onValueChange = viewModel::onStudentIdChange,
+                        label = { Text(stringResource(Res.string.student_id_label)) },
+                        modifier = Modifier.weight(1f)
+                    )
+                    Button(onClick = { viewModel.addStudent() }) {
+                        Text(stringResource(Res.string.button_add_student))
+                    }
+                }
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    items(uiState.students) { student ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(text = student, fontWeight = FontWeight.Bold)
+                            IconButton(onClick = { viewModel.removeStudent(student) }) {
+                                Icon(Icons.Filled.Delete, contentDescription = null)
+                            }
+                        }
+                    }
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = { viewModel.updateTrainingProgram() }, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(Res.string.button_save))
+                    }
+                    Button(onClick = { viewModel.deleteTrainingProgram() }, modifier = Modifier.weight(1f)) {
+                        Text(stringResource(Res.string.button_delete))
+                    }
+                }
+            }
+        } else {
+            LoadingContent(modifier = Modifier.fillMaxSize().padding(innerPadding))
+        }
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListScreen.kt
@@ -1,0 +1,68 @@
+package com.juanpablo0612.sigat.ui.training_programs.list
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.juanpablo0612.sigat.domain.model.TrainingProgram
+import com.juanpablo0612.sigat.ui.components.LoadingContent
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun TrainingProgramListScreen(
+    viewModel: TrainingProgramListViewModel = koinViewModel(),
+    windowSize: WindowSizeClass,
+    onAddProgramClick: () -> Unit,
+    onProgramClick: (String) -> Unit
+) {
+    val uiState = viewModel.uiState
+
+    Scaffold(
+        topBar = { TrainingProgramListTopBar() },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddProgramClick) {
+                Icon(Icons.Filled.Add, contentDescription = null)
+            }
+        }
+    ) { innerPadding ->
+        if (!uiState.loading) {
+            LazyColumn(
+                modifier = Modifier.padding(innerPadding).fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(uiState.programs, key = { it.id }) {
+                    TrainingProgramItem(program = it, onClick = { onProgramClick(it.id) })
+                }
+            }
+        } else {
+            LoadingContent(modifier = Modifier.padding(innerPadding).fillMaxSize())
+        }
+    }
+}
+
+@Composable
+private fun TrainingProgramItem(program: TrainingProgram, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable { onClick() }) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(text = program.name, style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
+            Text(text = program.schedule, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListTopBar.kt
@@ -1,0 +1,19 @@
+package com.juanpablo0612.sigat.ui.training_programs.list
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.stringResource
+import sigat.composeapp.generated.resources.Res
+import sigat.composeapp.generated.resources.training_programs_title
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TrainingProgramListTopBar() {
+    TopAppBar(
+        title = {
+            Text(text = stringResource(Res.string.training_programs_title))
+        }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListViewModel.kt
@@ -1,0 +1,45 @@
+package com.juanpablo0612.sigat.ui.training_programs.list
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.juanpablo0612.sigat.data.training_programs.TrainingProgramsRepository
+import com.juanpablo0612.sigat.domain.model.TrainingProgram
+import com.juanpablo0612.sigat.state_holders.UserStateHolder
+import kotlinx.coroutines.launch
+
+class TrainingProgramListViewModel(
+    private val repository: TrainingProgramsRepository,
+    private val userStateHolder: UserStateHolder,
+) : ViewModel() {
+    var uiState by mutableStateOf(TrainingProgramListUiState())
+        private set
+
+    init {
+        loadPrograms()
+    }
+
+    private fun loadPrograms() {
+        viewModelScope.launch {
+            uiState = uiState.copy(loading = true)
+            try {
+                val teacherId = userStateHolder.userState.user?.uid ?: return@launch
+                repository.getTrainingProgramsByTeacherId(teacherId).collect {
+                    uiState = uiState.copy(programs = it, loading = false)
+                }
+            } catch (e: Exception) {
+                uiState = uiState.copy(exception = e)
+            } finally {
+                uiState = uiState.copy(loading = false)
+            }
+        }
+    }
+}
+
+data class TrainingProgramListUiState(
+    val programs: List<TrainingProgram> = emptyList(),
+    val loading: Boolean = false,
+    val exception: Exception? = null
+)


### PR DESCRIPTION
## Summary
- manage training program creation fields in `AddTrainingProgramViewModel` with validation and change handlers
- expose field state and change handlers in `TrainingProgramDetailViewModel` for editing programs and students
- update corresponding Compose screens to bind to `uiState` and ViewModel callbacks

## Testing
- `./gradlew check` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22606712c83288cfd34119f52b7b2