### PR TITLE
Refactor training program date pickers and validation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/components/DatePickerTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/components/DatePickerTextField.kt
@@ -1,0 +1,69 @@
+package com.juanpablo0612.sigat.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DatePickerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.fillMaxWidth
+import org.jetbrains.compose.resources.stringResource
+import sigat.composeapp.generated.resources.Res
+import sigat.composeapp.generated.resources.button_accept
+import sigat.composeapp.generated.resources.button_cancel
+import com.juanpablo0612.sigat.utils.timestampToDayMonthYearFormat
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatePickerTextField(
+    label: String,
+    state: DatePickerState,
+    isError: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var showDialog by remember { mutableStateOf(false) }
+
+    OutlinedTextField(
+        value = state.selectedDateMillis?.let { timestampToDayMonthYearFormat(it) } ?: "",
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(label) },
+        trailingIcon = {
+            IconButton(onClick = { showDialog = true }) {
+                Icon(Icons.Filled.DateRange, contentDescription = null)
+            }
+        },
+        modifier = modifier.fillMaxWidth(),
+        isError = isError
+    )
+
+    if (showDialog) {
+        DatePickerDialog(
+            onDismissRequest = { showDialog = false },
+            confirmButton = {
+                TextButton(onClick = { showDialog = false }) {
+                    Text(stringResource(Res.string.button_accept))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) {
+                    Text(stringResource(Res.string.button_cancel))
+                }
+            }
+        ) {
+            DatePicker(state = state)
+        }
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
-import androidx.compose.material3.DateRangePicker
-import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -18,7 +16,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberDateRangePickerState
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,8 +28,11 @@ import sigat.composeapp.generated.resources.Res
 import sigat.composeapp.generated.resources.add_training_program_title
 import sigat.composeapp.generated.resources.button_save
 import sigat.composeapp.generated.resources.code_label
+import sigat.composeapp.generated.resources.end_date_label
 import sigat.composeapp.generated.resources.name_label
+import sigat.composeapp.generated.resources.start_date_label
 import sigat.composeapp.generated.resources.schedule_label
+import com.juanpablo0612.sigat.ui.components.DatePickerTextField
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,14 +42,15 @@ fun AddTrainingProgramScreen(
     onNavigateBack: () -> Unit
 ) {
     val uiState = viewModel.uiState
-    val datePickerState = rememberDateRangePickerState(initialDisplayMode = DisplayMode.Input)
+    val startDatePickerState = rememberDatePickerState(initialSelectedDateMillis = uiState.startDate)
+    val endDatePickerState = rememberDatePickerState(initialSelectedDateMillis = uiState.endDate)
 
-    LaunchedEffect(datePickerState.selectedStartDateMillis) {
-        datePickerState.selectedStartDateMillis?.let { viewModel.onStartDateChange(it) }
+    LaunchedEffect(startDatePickerState.selectedDateMillis) {
+        startDatePickerState.selectedDateMillis?.let { viewModel.onStartDateChange(it) }
     }
 
-    LaunchedEffect(datePickerState.selectedEndDateMillis) {
-        datePickerState.selectedEndDateMillis?.let { viewModel.onEndDateChange(it) }
+    LaunchedEffect(endDatePickerState.selectedDateMillis) {
+        endDatePickerState.selectedDateMillis?.let { viewModel.onEndDateChange(it) }
     }
 
     if (uiState.saved) {
@@ -88,9 +90,15 @@ fun AddTrainingProgramScreen(
                 modifier = Modifier.fillMaxWidth(),
                 isError = !uiState.validCode
             )
-            DateRangePicker(
-                state = datePickerState,
-                showModeToggle = false
+            DatePickerTextField(
+                label = stringResource(Res.string.start_date_label),
+                state = startDatePickerState,
+                isError = !uiState.validStartDate
+            )
+            DatePickerTextField(
+                label = stringResource(Res.string.end_date_label),
+                state = endDatePickerState,
+                isError = !uiState.validEndDate
             )
             OutlinedTextField(
                 value = uiState.schedule,

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramViewModel.kt
@@ -29,12 +29,12 @@ class AddTrainingProgramViewModel(
 
     fun onStartDateChange(newStartDate: Long) {
         uiState = uiState.copy(startDate = newStartDate)
-        validateStartDate()
+        validateDates()
     }
 
     fun onEndDateChange(newEndDate: Long) {
         uiState = uiState.copy(endDate = newEndDate)
-        validateEndDate()
+        validateDates()
     }
 
     fun onScheduleChange(newSchedule: String) {
@@ -50,14 +50,6 @@ class AddTrainingProgramViewModel(
         uiState = uiState.copy(validCode = uiState.code.toIntOrNull() != null)
     }
 
-    private fun validateStartDate() {
-        uiState = uiState.copy(validStartDate = uiState.startDate != null)
-    }
-
-    private fun validateEndDate() {
-        uiState = uiState.copy(validEndDate = uiState.endDate != null)
-    }
-
     private fun validateSchedule() {
         uiState = uiState.copy(validSchedule = uiState.schedule.isNotBlank())
     }
@@ -65,13 +57,22 @@ class AddTrainingProgramViewModel(
     private fun validateFields() {
         validateName()
         validateCode()
-        validateStartDate()
-        validateEndDate()
+        validateDates()
         validateSchedule()
     }
 
     private fun allFieldsValid(): Boolean {
         return uiState.validName && uiState.validCode && uiState.validStartDate && uiState.validEndDate && uiState.validSchedule
+    }
+
+    private fun validateDates() {
+        val start = uiState.startDate
+        val end = uiState.endDate
+        val orderValid = if (start != null && end != null) start <= end else true
+        uiState = uiState.copy(
+            validStartDate = start != null && orderValid,
+            validEndDate = end != null && orderValid
+        )
     }
 
     fun addTrainingProgram() {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
@@ -11,11 +11,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -24,16 +21,12 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -41,14 +34,9 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.components.LoadingContent
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.number
-import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import sigat.composeapp.generated.resources.Res
-import sigat.composeapp.generated.resources.button_accept
-import sigat.composeapp.generated.resources.button_cancel
 import sigat.composeapp.generated.resources.button_delete
 import sigat.composeapp.generated.resources.button_save
 import sigat.composeapp.generated.resources.code_label
@@ -58,8 +46,7 @@ import sigat.composeapp.generated.resources.schedule_label
 import sigat.composeapp.generated.resources.start_date_label
 import sigat.composeapp.generated.resources.student_id_label
 import sigat.composeapp.generated.resources.training_program_detail_title
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
+import com.juanpablo0612.sigat.ui.components.DatePickerTextField
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -222,60 +209,4 @@ fun TrainingProgramDetailScreen(
             )
         }
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun DatePickerTextField(
-    label: String,
-    state: DatePickerState,
-    isError: Boolean
-) {
-    var showDialog by remember { mutableStateOf(false) }
-
-    OutlinedTextField(
-        value = formatEpochMillisAsDMY(state.selectedDateMillis ?: 0),
-        onValueChange = {},
-        readOnly = true,
-        label = { Text(label) },
-        trailingIcon = {
-            IconButton(onClick = { showDialog = true }) {
-                Icon(Icons.Filled.DateRange, contentDescription = null)
-            }
-        },
-        modifier = Modifier.fillMaxWidth(),
-        isError = isError
-    )
-
-    if (showDialog) {
-        DatePickerDialog(
-            onDismissRequest = { showDialog = false },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showDialog = false
-                    }
-                ) { Text(stringResource(Res.string.button_accept)) }
-            },
-            dismissButton = {
-                TextButton(onClick = {
-                    showDialog = false
-                }) { Text(stringResource(Res.string.button_cancel)) }
-            }
-        ) {
-            DatePicker(state = state)
-        }
-    }
-}
-
-@OptIn(ExperimentalTime::class)
-private fun formatEpochMillisAsDMY(
-    epochMillis: Long,
-    timeZone: TimeZone = TimeZone.currentSystemDefault()
-): String {
-    val date = Instant.fromEpochMilliseconds(epochMillis).toLocalDateTime(timeZone).date
-    val y = date.year.toString().padStart(4, '0')
-    val m = date.month.number.toString().padStart(2, '0')
-    val d = date.day.toString().padStart(2, '0')
-    return "$d/$m/$y"
 }

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
@@ -35,8 +35,8 @@ class TrainingProgramDetailViewModel(
                         id = program.id,
                         name = program.name,
                         code = program.code.toString(),
-                        startDate = program.startDate.toString(),
-                        endDate = program.endDate.toString(),
+                        startDate = program.startDate,
+                        endDate = program.endDate,
                         schedule = program.schedule,
                         teacherUserId = program.teacherUserId,
                         students = program.students
@@ -57,20 +57,14 @@ class TrainingProgramDetailViewModel(
         uiState = uiState.copy(code = newCode, validCode = newCode.toIntOrNull() != null)
     }
 
-    fun onStartDateChange(newStartDate: String) {
-        val valid = newStartDate.toLongOrNull() != null
-        val validEnd = uiState.endDate.toLongOrNull()?.let { end ->
-            newStartDate.toLongOrNull()?.let { start -> start <= end } ?: false
-        } ?: true
-        uiState = uiState.copy(startDate = newStartDate, validStartDate = valid && validEnd)
-        if (!validEnd) uiState = uiState.copy(validEndDate = false)
+    fun onStartDateChange(newStartDate: Long) {
+        uiState = uiState.copy(startDate = newStartDate)
+        validateDates()
     }
 
-    fun onEndDateChange(newEndDate: String) {
-        val endLong = newEndDate.toLongOrNull()
-        val startLong = uiState.startDate.toLongOrNull()
-        val valid = endLong != null && (startLong == null || startLong <= endLong)
-        uiState = uiState.copy(endDate = newEndDate, validEndDate = valid)
+    fun onEndDateChange(newEndDate: Long) {
+        uiState = uiState.copy(endDate = newEndDate)
+        validateDates()
     }
 
     fun onScheduleChange(newSchedule: String) {
@@ -84,8 +78,7 @@ class TrainingProgramDetailViewModel(
     private fun validateFields() {
         onNameChange(uiState.name)
         onCodeChange(uiState.code)
-        onStartDateChange(uiState.startDate)
-        onEndDateChange(uiState.endDate)
+        validateDates()
         onScheduleChange(uiState.schedule)
     }
 
@@ -105,8 +98,8 @@ class TrainingProgramDetailViewModel(
                         id = uiState.id,
                         name = uiState.name,
                         code = uiState.code.toInt(),
-                        startDate = uiState.startDate.toLong(),
-                        endDate = uiState.endDate.toLong(),
+                        startDate = uiState.startDate!!,
+                        endDate = uiState.endDate!!,
                         schedule = uiState.schedule,
                         teacherUserId = uiState.teacherUserId,
                         students = uiState.students
@@ -151,6 +144,16 @@ class TrainingProgramDetailViewModel(
             }
         }
     }
+
+    private fun validateDates() {
+        val start = uiState.startDate
+        val end = uiState.endDate
+        val orderValid = if (start != null && end != null) start <= end else true
+        uiState = uiState.copy(
+            validStartDate = start != null && orderValid,
+            validEndDate = end != null && orderValid
+        )
+    }
 }
 
 data class TrainingProgramDetailUiState(
@@ -159,9 +162,9 @@ data class TrainingProgramDetailUiState(
     val validName: Boolean = true,
     val code: String = "",
     val validCode: Boolean = true,
-    val startDate: String = "",
+    val startDate: Long? = null,
     val validStartDate: Boolean = true,
-    val endDate: String = "",
+    val endDate: Long? = null,
     val validEndDate: Boolean = true,
     val schedule: String = "",
     val validSchedule: Boolean = true,


### PR DESCRIPTION
## Summary
- Introduce reusable `DatePickerTextField` composable for consistent date selection.
- Update training program add and detail screens to use new date picker and shared date validation logic.
- Replace string-based date handling with `Long` values in detail view model for consistency.

## Testing
- `sh gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26beead248328bf2ffa0b04621287