### PR TITLE
refactor: align text fields across screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/actions/add_action/AddActionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/actions/add_action/AddActionScreen.kt
@@ -34,6 +34,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -265,6 +268,10 @@ fun ActionDetails(
                 },
                 isError = !uiState.validDescription,
                 enabled = !uiState.loading,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences,
+                    imeAction = ImeAction.Done
+                ),
                 modifier = Modifier.fillMaxWidth()
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/auth/components/AuthTextFields.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/auth/components/AuthTextFields.kt
@@ -128,7 +128,8 @@ fun PasswordTextField(
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Password,
             imeAction = imeAction
-        )
+        ),
+        singleLine = true
     )
 }
 
@@ -162,7 +163,8 @@ fun ConfirmPasswordTextField(
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Password,
             imeAction = imeAction
-        )
+        ),
+        singleLine = true
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/components/DatePickerTextField.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/components/DatePickerTextField.kt
@@ -47,7 +47,8 @@ fun DatePickerTextField(
             }
         },
         modifier = modifier.fillMaxWidth(),
-        isError = isError
+        isError = isError,
+        singleLine = true
     )
 
     if (showDialog) {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
@@ -19,6 +19,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -84,7 +88,12 @@ fun AddTrainingProgramScreen(
                     label = { Text(stringResource(Res.string.name_label)) },
                     modifier = Modifier.fillMaxWidth(),
                     isError = !uiState.validName,
-                    enabled = !uiState.loading
+                    enabled = !uiState.loading,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        imeAction = ImeAction.Next
+                    )
                 )
                 OutlinedTextField(
                     value = uiState.code,
@@ -92,7 +101,25 @@ fun AddTrainingProgramScreen(
                     label = { Text(stringResource(Res.string.code_label)) },
                     modifier = Modifier.fillMaxWidth(),
                     isError = !uiState.validCode,
-                    enabled = !uiState.loading
+                    enabled = !uiState.loading,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    )
+                )
+                OutlinedTextField(
+                    value = uiState.schedule,
+                    onValueChange = viewModel::onScheduleChange,
+                    label = { Text(stringResource(Res.string.schedule_label)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = !uiState.validSchedule,
+                    enabled = !uiState.loading,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences,
+                        imeAction = ImeAction.Done
+                    )
                 )
                 DatePickerTextField(
                     label = stringResource(Res.string.start_date_label),
@@ -104,14 +131,6 @@ fun AddTrainingProgramScreen(
                     label = stringResource(Res.string.end_date_label),
                     state = endDatePickerState,
                     isError = !uiState.validEndDate,
-                    enabled = !uiState.loading
-                )
-                OutlinedTextField(
-                    value = uiState.schedule,
-                    onValueChange = viewModel::onScheduleChange,
-                    label = { Text(stringResource(Res.string.schedule_label)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    isError = !uiState.validSchedule,
                     enabled = !uiState.loading
                 )
                 Button(

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.components.LoadingContent
 import org.jetbrains.compose.resources.stringResource
@@ -106,7 +107,10 @@ fun TrainingProgramDetailScreen(
                         isError = !uiState.validName,
                         singleLine = true,
                         enabled = !uiState.loading,
-                        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences)
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Sentences,
+                            imeAction = ImeAction.Next
+                        )
                     )
                 }
                 item {
@@ -118,10 +122,28 @@ fun TrainingProgramDetailScreen(
                         isError = !uiState.validCode,
                         singleLine = true,
                         enabled = !uiState.loading,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = ImeAction.Next
+                        )
                     )
                 }
 
+                item {
+                    OutlinedTextField(
+                        value = uiState.schedule,
+                        onValueChange = viewModel::onScheduleChange,
+                        label = { Text(stringResource(Res.string.schedule_label)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        isError = !uiState.validSchedule,
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Sentences,
+                            imeAction = ImeAction.Done
+                        ),
+                        enabled = !uiState.loading
+                    )
+                }
                 item {
                     DatePickerTextField(
                         label = stringResource(Res.string.start_date_label),
@@ -140,18 +162,6 @@ fun TrainingProgramDetailScreen(
                 }
 
                 item {
-                    OutlinedTextField(
-                        value = uiState.schedule,
-                        onValueChange = viewModel::onScheduleChange,
-                        label = { Text(stringResource(Res.string.schedule_label)) },
-                        modifier = Modifier.fillMaxWidth(),
-                        isError = !uiState.validSchedule,
-                        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
-                        enabled = !uiState.loading
-                    )
-                }
-
-                item {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -162,7 +172,10 @@ fun TrainingProgramDetailScreen(
                             label = { Text(stringResource(Res.string.student_id_label)) },
                             modifier = Modifier.weight(1f),
                             singleLine = true,
-                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Number,
+                                imeAction = ImeAction.Done
+                            ),
                             enabled = !uiState.loading
                         )
                         IconButton(onClick = { viewModel.addStudent() }, enabled = !uiState.loading) {


### PR DESCRIPTION
## Summary
- standardize action description input with keyboard options
- enforce single-line behavior for auth password fields
- reorder training program fields and improve keyboard navigation

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a473192ac48328b0386e9388c63dd2