### PR TITLE
Externalize report filename and clarify role string keys

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -96,12 +96,13 @@
     <string name="generate_report_button">Generar informe</string>
     <string name="select_template">Seleccionar plantilla</string>
     <string name="select_output_file">Seleccionar archivo de salida</string>
+    <string name="default_report_file_name">informe</string>
 
     <!-- Roles de usuario -->
-    <string name="role">Tu rol:</string>
-    <string name="role_fa">Facilitador</string>
-    <string name="role_ap">Aprendiz</string>
-    <string name="role_ad">Administrador</string>
+    <string name="role_label">Tu rol:</string>
+    <string name="role_facilitator">Facilitador</string>
+    <string name="role_apprentice">Aprendiz</string>
+    <string name="role_administrator">Administrador</string>
     <string name="role_unknown">Desconocido</string>
 
     <!-- Formulario de acción -->

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -98,12 +98,13 @@
     <string name="generate_report_button">Generate Report</string>
     <string name="select_template">Select Template</string>
     <string name="select_output_file">Select Output File</string>
+    <string name="default_report_file_name">report</string>
 
     <!-- User Roles -->
-    <string name="role">Your Role:</string>
-    <string name="role_fa">Facilitator</string>
-    <string name="role_ap">Apprentice</string>
-    <string name="role_ad">Administrator</string>
+    <string name="role_label">Your Role:</string>
+    <string name="role_facilitator">Facilitator</string>
+    <string name="role_apprentice">Apprentice</string>
+    <string name="role_administrator">Administrator</string>
     <string name="role_unknown">Unknown</string>
 
     <!-- Action Form -->

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/reports/generate_report/GenerateReportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/reports/generate_report/GenerateReportScreen.kt
@@ -26,6 +26,7 @@ import org.jetbrains.compose.resources.stringResource
 import sigat.composeapp.generated.resources.Res
 import sigat.composeapp.generated.resources.generate_report_button
 import sigat.composeapp.generated.resources.generate_report_title
+import sigat.composeapp.generated.resources.default_report_file_name
 import sigat.composeapp.generated.resources.select_output_file
 import sigat.composeapp.generated.resources.select_template
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -48,10 +49,10 @@ fun GenerateReportScreen(viewModel: GenerateReportViewModel = koinViewModel()) {
 
     Scaffold(
         topBar = { TopAppBar(title = { Text(stringResource(Res.string.generate_report_title)) }) }
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(innerPadding),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             ContractFields(
                 contract = uiState.contract,
@@ -73,8 +74,9 @@ fun GenerateReportScreen(viewModel: GenerateReportViewModel = koinViewModel()) {
             TemplateSelector(
                 onClick = { templateFileLauncher.launch() }
             )
+            val defaultFileName = stringResource(Res.string.default_report_file_name)
             OutputFileSelector(
-                onClick = { outputFileLauncher.launch("informe", "docx") }
+                onClick = { outputFileLauncher.launch(defaultFileName, "docx") }
             )
             Button(onClick = viewModel::onGenerateReportClick) {
                 Text(text = stringResource(Res.string.generate_report_button))


### PR DESCRIPTION
## Summary
- Replace hardcoded default report filename with string resource
- Rename user role string keys for clarity

## Testing
- `./gradlew build` *(fails: SDK location not found)*
- `./gradlew composeApp:compileCommonMainKotlinMetadata`


------
https://chatgpt.com/codex/tasks/task_e_68a4ecac39f083288d930e34820ab5be