### PR TITLE
feat: responsive navigation and wide-screen layouts

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/admin/manage_roles/ManageRolesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/admin/manage_roles/ManageRolesScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -50,13 +51,22 @@ fun ManageRolesScreen(
         }
     }
 
+    val gridModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.width(800.dp)
+    } else {
+        Modifier.fillMaxWidth()
+    }
+
     Scaffold(
         topBar = {
             ManageRolesTopBar()
         }
     ) { innerPadding ->
         Box(
-            modifier = Modifier.padding(innerPadding).padding(horizontal = Dimens.PaddingMedium)
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
         ) {
             if (uiState.initialLoading) {
                 LoadingContent(modifier = Modifier.fillMaxSize())
@@ -67,7 +77,8 @@ fun ManageRolesScreen(
                     users = uiState.users,
                     roles = uiState.roles,
                     cols = cols,
-                    onUserRoleChange = viewModel::updateUserRole
+                    onUserRoleChange = viewModel::updateUserRole,
+                    modifier = gridModifier.padding(horizontal = Dimens.PaddingMedium)
                 )
             }
         }
@@ -80,13 +91,14 @@ private fun ManageRolesContent(
     roles: List<Role>,
     cols: GridCells,
     applyingChangesToUser: User? = null,
-    onUserRoleChange: (User, Role) -> Unit
+    onUserRoleChange: (User, Role) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     LazyVerticalGrid(
         columns = cols,
         verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall),
         horizontalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall),
-        modifier = Modifier.fillMaxWidth()
+        modifier = modifier
     ) {
         items(users) {
             UserRoleCard(

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/auth/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/auth/login/LoginScreen.kt
@@ -2,10 +2,12 @@ package com.juanpablo0612.sigat.ui.auth.login
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -14,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -22,6 +25,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.theme.Dimens
 import com.juanpablo0612.sigat.ui.auth.components.EmailTextField
 import com.juanpablo0612.sigat.ui.auth.components.PasswordTextField
@@ -55,7 +59,8 @@ fun LoginScreen(
         onPasswordChange = viewModel::onPasswordChange,
         onPasswordVisibilityChange = viewModel::onPasswordVisibilityChange,
         onLoginClick = viewModel::onLoginClick,
-        onNavigateToRegister = onNavigateToRegister
+        onNavigateToRegister = onNavigateToRegister,
+        windowSize = windowSize
     )
 }
 
@@ -66,18 +71,28 @@ fun LoginScreenContent(
     onPasswordChange: (String) -> Unit,
     onPasswordVisibilityChange: () -> Unit,
     onLoginClick: () -> Unit,
-    onNavigateToRegister: () -> Unit
+    onNavigateToRegister: () -> Unit,
+    windowSize: WindowSizeClass
 ) {
+    val columnWidthModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.width(400.dp)
+    } else {
+        Modifier.fillMaxWidth()
+    }
     Scaffold { innerPadding ->
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = Dimens.PaddingMedium)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(Dimens.PaddingMedium, Alignment.CenterVertically),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
         ) {
+            Column(
+                modifier = columnWidthModifier
+                    .padding(horizontal = Dimens.PaddingMedium)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Dimens.PaddingMedium, Alignment.CenterVertically),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
             Text(
                 text = stringResource(Res.string.login_title),
                 style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold)

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/auth/register/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/auth/register/RegisterScreen.kt
@@ -2,10 +2,12 @@ package com.juanpablo0612.sigat.ui.auth.register
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -14,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -22,6 +25,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.theme.Dimens
 import com.juanpablo0612.sigat.ui.auth.components.ConfirmPasswordTextField
 import com.juanpablo0612.sigat.ui.auth.components.EmailTextField
@@ -62,7 +66,8 @@ fun RegisterScreen(
         onPasswordVisibilityChange = viewModel::onPasswordVisibilityChange,
         onRegisterClick = viewModel::onRegisterClick,
         onNavigateToLogin = onNavigateBack,
-        onNavigateBack = onNavigateBack
+        onNavigateBack = onNavigateBack,
+        windowSize = windowSize
     )
 }
 
@@ -79,22 +84,32 @@ fun RegisterScreenContent(
     onPasswordVisibilityChange: () -> Unit,
     onRegisterClick: () -> Unit,
     onNavigateToLogin: () -> Unit,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    windowSize: WindowSizeClass
 ) {
+    val columnWidthModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.width(400.dp)
+    } else {
+        Modifier.fillMaxWidth()
+    }
     Scaffold(
         topBar = {
             RegisterTopAppBar(onNavigateBack = onNavigateBack)
         }
     ) { innerPadding ->
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = Dimens.PaddingMedium)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(Dimens.PaddingMedium),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(innerPadding),
+            contentAlignment = Alignment.TopCenter
         ) {
+            Column(
+                modifier = columnWidthModifier
+                    .padding(horizontal = Dimens.PaddingMedium)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Dimens.PaddingMedium),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
             FirstNameTextField(
                 value = uiState.firstName,
                 onValueChange = onFirstNameChange,
@@ -178,6 +193,7 @@ fun RegisterScreenContent(
                 modifier = Modifier.clickable(onClick = onNavigateToLogin),
                 style = MaterialTheme.typography.bodyLarge
             )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/AppNavigation.kt
@@ -3,7 +3,10 @@ package com.juanpablo0612.sigat.ui.navigation
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -12,14 +15,18 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
@@ -71,6 +78,7 @@ fun AppNavigation(
             val currentDestination = backStackEntry?.destination
             val bottomRoutes = destinations.map { it.screen::class.qualifiedName }
             val showBottomBar = currentDestination?.route in bottomRoutes
+            val isCompact = windowSize.widthSizeClass == WindowWidthSizeClass.Compact
 
             LaunchedEffect(userState.isLoggedIn) {
                 if (userState.isLoggedIn) {
@@ -85,49 +93,99 @@ fun AppNavigation(
                 }
             }
 
-            Column {
-                NavHost(
-                    navController = navController,
-                    startDestination = startDestination,
-                    modifier = Modifier.weight(1f).imePadding(),
-                    enterTransition = {
-                        slideInHorizontally { height -> height }
-                    },
-                    exitTransition = {
-                        slideOutHorizontally { height -> -height }
-                    },
-                    popEnterTransition = {
-                        slideInHorizontally { height -> -height }
-                    },
-                    popExitTransition = {
-                        slideOutHorizontally { height -> height }
+            val navigateTo: (Screen) -> Unit = {
+                navController.navigate(it) {
+                    launchSingleTop = true
+                    restoreState = true
+                    popUpTo(navController.graph.startDestinationId) {
+                        saveState = true
                     }
-                ) {
-                    addLoginScreen(navController, windowSize, viewModel::loadCurrentUser)
-                    addRegisterScreen(navController, windowSize, viewModel::loadCurrentUser)
-                    addManageRolesScreen(windowSize)
-                    addTrainingProgramsScreen(navController, windowSize)
-                    addActionsScreen(navController, windowSize)
-                    addReportsScreen(windowSize)
-                    addAddActionScreen(navController, windowSize)
-                    addAddTrainingProgramScreen(navController, windowSize)
-                    addTrainingProgramDetailScreen(navController, windowSize)
                 }
+            }
 
-                AnimatedVisibility(showBottomBar) {
-                    BottomNavigationBar(
-                        destinations = destinations,
-                        currentDestination = currentDestination!!,
-                        onNavigate = {
-                            navController.navigate(it) {
-                                launchSingleTop = true
-                                restoreState = true
-                                popUpTo(navController.graph.startDestinationId) {
-                                    saveState = true
-                                }
-                            }
+            if (isCompact) {
+                Column {
+                    NavHost(
+                        navController = navController,
+                        startDestination = startDestination,
+                        modifier = Modifier.weight(1f).imePadding(),
+                        enterTransition = {
+                            slideInHorizontally { fullWidth -> fullWidth }
+                        },
+                        exitTransition = {
+                            slideOutHorizontally { fullWidth -> -fullWidth }
+                        },
+                        popEnterTransition = {
+                            slideInHorizontally { fullWidth -> -fullWidth }
+                        },
+                        popExitTransition = {
+                            slideOutHorizontally { fullWidth -> fullWidth }
                         }
-                    )
+                    ) {
+                        addLoginScreen(navController, windowSize, viewModel::loadCurrentUser)
+                        addRegisterScreen(navController, windowSize, viewModel::loadCurrentUser)
+                        addManageRolesScreen(windowSize)
+                        addTrainingProgramsScreen(navController, windowSize)
+                        addActionsScreen(navController, windowSize)
+                        addReportsScreen(windowSize)
+                        addAddActionScreen(navController, windowSize)
+                        addAddTrainingProgramScreen(navController, windowSize)
+                        addTrainingProgramDetailScreen(navController, windowSize)
+                    }
+
+                    AnimatedVisibility(showBottomBar) {
+                        BottomNavigationBar(
+                            destinations = destinations,
+                            currentDestination = currentDestination!!,
+                            onNavigate = navigateTo
+                        )
+                    }
+                }
+            } else {
+                Row {
+                    AnimatedVisibility(
+                        visible = showBottomBar,
+                        enter = slideInHorizontally { -it },
+                        exit = slideOutHorizontally { -it }
+                    ) {
+                        Box(
+                            modifier = Modifier.fillMaxHeight(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            NavigationRailBar(
+                                destinations = destinations,
+                                currentDestination = currentDestination!!,
+                                onNavigate = navigateTo
+                            )
+                        }
+                    }
+                    NavHost(
+                        navController = navController,
+                        startDestination = startDestination,
+                        modifier = Modifier.weight(1f).imePadding(),
+                        enterTransition = {
+                            slideInHorizontally { fullWidth -> fullWidth }
+                        },
+                        exitTransition = {
+                            slideOutHorizontally { fullWidth -> -fullWidth }
+                        },
+                        popEnterTransition = {
+                            slideInHorizontally { fullWidth -> -fullWidth }
+                        },
+                        popExitTransition = {
+                            slideOutHorizontally { fullWidth -> fullWidth }
+                        }
+                    ) {
+                        addLoginScreen(navController, windowSize, viewModel::loadCurrentUser)
+                        addRegisterScreen(navController, windowSize, viewModel::loadCurrentUser)
+                        addManageRolesScreen(windowSize)
+                        addTrainingProgramsScreen(navController, windowSize)
+                        addActionsScreen(navController, windowSize)
+                        addReportsScreen(windowSize)
+                        addAddActionScreen(navController, windowSize)
+                        addAddTrainingProgramScreen(navController, windowSize)
+                        addTrainingProgramDetailScreen(navController, windowSize)
+                    }
                 }
             }
         }
@@ -143,6 +201,37 @@ fun BottomNavigationBar(
     NavigationBar {
         destinations.forEach { destination ->
             NavigationBarItem(
+                icon = {
+                    Icon(
+                        imageVector = destination.icon,
+                        contentDescription = stringResource(destination.label)
+                    )
+                },
+                label = {
+                    Text(
+                        stringResource(destination.label),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                selected = currentDestination.hierarchy.any {
+                    it.hasRoute(destination.screen::class)
+                },
+                onClick = { onNavigate(destination.screen) }
+            )
+        }
+    }
+}
+
+@Composable
+fun NavigationRailBar(
+    destinations: List<HomeDestinations>,
+    currentDestination: NavDestination,
+    onNavigate: (Screen) -> Unit
+) {
+    NavigationRail {
+        destinations.forEach { destination ->
+            NavigationRailItem(
                 icon = {
                     Icon(
                         imageVector = destination.icon,
@@ -228,7 +317,7 @@ fun NavGraphBuilder.addActionsScreen(
 
 fun NavGraphBuilder.addReportsScreen(windowSize: WindowSizeClass) {
     composable<Screen.Reports> {
-        GenerateReportScreen()
+        GenerateReportScreen(windowSize = windowSize)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/reports/generate_report/GenerateReportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/reports/generate_report/GenerateReportScreen.kt
@@ -1,10 +1,12 @@
 package com.juanpablo0612.sigat.ui.reports.generate_report
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -18,8 +20,12 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.contracts.ContractFields
 import com.juanpablo0612.sigat.ui.theme.Dimens
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -37,7 +43,10 @@ import sigat.composeapp.generated.resources.select_template
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GenerateReportScreen(viewModel: GenerateReportViewModel = koinViewModel()) {
+fun GenerateReportScreen(
+    viewModel: GenerateReportViewModel = koinViewModel(),
+    windowSize: WindowSizeClass
+) {
     val uiState = viewModel.uiState
 
     val templateFileLauncher = rememberFilePickerLauncher(type = FileKitType.File("doc", "docx")) { file ->
@@ -51,17 +60,27 @@ fun GenerateReportScreen(viewModel: GenerateReportViewModel = koinViewModel()) {
         }
     }
 
+    val columnWidthModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.width(600.dp)
+    } else {
+        Modifier.fillMaxWidth()
+    }
+
     Scaffold(
         topBar = { TopAppBar(title = { Text(stringResource(Res.string.generate_report_title)) }) }
     ) { innerPadding ->
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = Dimens.PaddingMedium)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)
+                .padding(innerPadding),
+            contentAlignment = Alignment.TopCenter
         ) {
+            Column(
+                modifier = columnWidthModifier
+                    .padding(horizontal = Dimens.PaddingMedium)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)
+            ) {
             ContractFields(
                 contract = uiState.contract,
                 onCityChange = viewModel::onCityChange,

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/add/AddTrainingProgramScreen.kt
@@ -3,8 +3,11 @@ package com.juanpablo0612.sigat.ui.training_programs.add
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -19,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -26,6 +30,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.theme.Dimens
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -64,6 +70,12 @@ fun AddTrainingProgramScreen(
         LaunchedEffect(Unit) { onNavigateBack() }
     }
 
+    val columnWidthModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.width(600.dp)
+    } else {
+        Modifier.fillMaxWidth()
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -79,9 +91,14 @@ fun AddTrainingProgramScreen(
             )
         }
     ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) {
+        Box(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
+        ) {
             Column(
-                modifier = Modifier
+                modifier = columnWidthModifier
                     .padding(horizontal = Dimens.PaddingMedium)
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
@@ -33,6 +35,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -40,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -99,6 +103,12 @@ fun TrainingProgramDetailScreen(
         }
     }
 
+    val listModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.width(600.dp).fillMaxHeight()
+    } else {
+        Modifier.fillMaxSize()
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -114,12 +124,15 @@ fun TrainingProgramDetailScreen(
             )
         }
     ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding).padding(horizontal = Dimens.PaddingMedium)) {
+        Box(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            contentAlignment = Alignment.TopCenter
+        ) {
             if (uiState.id.isNotEmpty()) {
                 LazyColumn(
-                    modifier = Modifier
-                        .padding(vertical = Dimens.PaddingMedium)
-                        .fillMaxSize(),
+                    modifier = listModifier.padding(vertical = Dimens.PaddingMedium),
                     verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall),
                     contentPadding = PaddingValues(bottom = Dimens.PaddingMedium)
                 ) {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/list/TrainingProgramListScreen.kt
@@ -2,10 +2,12 @@ package com.juanpablo0612.sigat.ui.training_programs.list
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -17,9 +19,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.domain.model.TrainingProgram
 import com.juanpablo0612.sigat.ui.components.LoadingContent
 import com.juanpablo0612.sigat.ui.theme.Dimens
@@ -37,6 +42,12 @@ fun TrainingProgramListScreen(
 ) {
     val uiState = viewModel.uiState
 
+    val listModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.width(600.dp)
+    } else {
+        Modifier.fillMaxWidth()
+    }
+
     Scaffold(
         topBar = { TrainingProgramListTopBar() },
         floatingActionButton = {
@@ -51,12 +62,19 @@ fun TrainingProgramListScreen(
         }
     ) { innerPadding ->
         if (!uiState.loading) {
-            LazyColumn(
-                modifier = Modifier.padding(innerPadding).fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)
+            Box(
+                modifier = Modifier
+                    .padding(innerPadding)
+                    .fillMaxSize(),
+                contentAlignment = Alignment.TopCenter
             ) {
-                items(uiState.programs, key = { it.id }) {
-                    TrainingProgramItem(program = it, onClick = { onProgramClick(it.id) })
+                LazyColumn(
+                    modifier = listModifier,
+                    verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)
+                ) {
+                    items(uiState.programs, key = { it.id }) {
+                        TrainingProgramItem(program = it, onClick = { onProgramClick(it.id) })
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- animate and center navigation rail for large layouts
- make report generation and training program screens responsive
- center manage roles grid on wide displays

## Testing
- `./gradlew composeApp:build` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa01213c048328b0a2a04bd71b608e