### PR TITLE
Improve navigation animations and responsive report screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/navigation/AppNavigation.kt
@@ -2,13 +2,17 @@ package com.juanpablo0612.sigat.ui.navigation
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -25,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.Alignment
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -130,7 +135,11 @@ fun AppNavigation(
                         addTrainingProgramDetailScreen(navController, windowSize)
                     }
 
-                    AnimatedVisibility(showBottomBar) {
+                    AnimatedVisibility(
+                        visible = showBottomBar,
+                        enter = slideInVertically { it },
+                        exit = slideOutVertically { it }
+                    ) {
                         BottomNavigationBar(
                             destinations = destinations,
                             currentDestination = currentDestination!!,
@@ -140,7 +149,11 @@ fun AppNavigation(
                 }
             } else {
                 Row {
-                    if (showBottomBar) {
+                    AnimatedVisibility(
+                        visible = showBottomBar,
+                        enter = slideInHorizontally { -it },
+                        exit = slideOutHorizontally { -it }
+                    ) {
                         NavigationRailBar(
                             destinations = destinations,
                             currentDestination = currentDestination!!,
@@ -217,27 +230,33 @@ fun NavigationRailBar(
     currentDestination: NavDestination,
     onNavigate: (Screen) -> Unit
 ) {
-    NavigationRail {
-        destinations.forEach { destination ->
-            NavigationRailItem(
-                icon = {
-                    Icon(
-                        imageVector = destination.icon,
-                        contentDescription = stringResource(destination.label)
-                    )
-                },
-                label = {
-                    Text(
-                        stringResource(destination.label),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                },
-                selected = currentDestination.hierarchy.any {
-                    it.hasRoute(destination.screen::class)
-                },
-                onClick = { onNavigate(destination.screen) }
-            )
+    NavigationRail(modifier = Modifier.fillMaxHeight()) {
+        Column(
+            modifier = Modifier.fillMaxHeight(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            destinations.forEach { destination ->
+                NavigationRailItem(
+                    icon = {
+                        Icon(
+                            imageVector = destination.icon,
+                            contentDescription = stringResource(destination.label)
+                        )
+                    },
+                    label = {
+                        Text(
+                            stringResource(destination.label),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    },
+                    selected = currentDestination.hierarchy.any {
+                        it.hasRoute(destination.screen::class)
+                    },
+                    onClick = { onNavigate(destination.screen) }
+                )
+            }
         }
     }
 }
@@ -305,7 +324,7 @@ fun NavGraphBuilder.addActionsScreen(
 
 fun NavGraphBuilder.addReportsScreen(windowSize: WindowSizeClass) {
     composable<Screen.Reports> {
-        GenerateReportScreen()
+        GenerateReportScreen(windowSize = windowSize)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/reports/generate_report/GenerateReportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/reports/generate_report/GenerateReportScreen.kt
@@ -1,10 +1,13 @@
 package com.juanpablo0612.sigat.ui.reports.generate_report
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -18,8 +21,12 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.contracts.ContractFields
 import com.juanpablo0612.sigat.ui.theme.Dimens
 import io.github.vinceglb.filekit.dialogs.FileKitType
@@ -37,7 +44,10 @@ import sigat.composeapp.generated.resources.select_template
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GenerateReportScreen(viewModel: GenerateReportViewModel = koinViewModel()) {
+fun GenerateReportScreen(
+    viewModel: GenerateReportViewModel = koinViewModel(),
+    windowSize: WindowSizeClass
+) {
     val uiState = viewModel.uiState
 
     val templateFileLauncher = rememberFilePickerLauncher(type = FileKitType.File("doc", "docx")) { file ->
@@ -51,17 +61,27 @@ fun GenerateReportScreen(viewModel: GenerateReportViewModel = koinViewModel()) {
         }
     }
 
+    val contentModifier = if (windowSize.widthSizeClass > WindowWidthSizeClass.Compact) {
+        Modifier.widthIn(max = 600.dp)
+    } else {
+        Modifier.fillMaxWidth()
+    }
+
     Scaffold(
         topBar = { TopAppBar(title = { Text(stringResource(Res.string.generate_report_title)) }) }
     ) { innerPadding ->
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = Dimens.PaddingMedium)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)
+                .padding(innerPadding),
+            contentAlignment = Alignment.TopCenter
         ) {
+            Column(
+                modifier = contentModifier
+                    .padding(horizontal = Dimens.PaddingMedium)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Dimens.PaddingSmall)
+            ) {
             ContractFields(
                 contract = uiState.contract,
                 onCityChange = viewModel::onCityChange,


### PR DESCRIPTION
## Summary
- Animate bottom navigation and navigation rail visibility with slide transitions
- Center navigation rail items for a better large-screen experience
- Make Generate Report screen responsive and centered based on window size

## Testing
- `./gradlew composeApp:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0e1d3e10832890ec478234821a97