### PR TITLE
Add attendance tracking to training program detail

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -85,6 +85,13 @@
     <string name="button_add_student">Agregar estudiante</string>
     <string name="button_delete">Eliminar</string>
 
+    <!-- Asistencia -->
+    <string name="attendance_label">Asistencia</string>
+    <string name="attendance_date_label">Fecha</string>
+    <string name="present_label">Presente</string>
+    <string name="absent_label">Ausente</string>
+    <string name="save_attendance_button">Guardar asistencia</string>
+
     <!-- Contrato -->
     <string name="city_label">Ciudad</string>
     <string name="city_error">Ingrese una ciudad</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -87,6 +87,13 @@
     <string name="button_add_student">Add Student</string>
     <string name="button_delete">Delete</string>
 
+    <!-- Attendance -->
+    <string name="attendance_label">Attendance</string>
+    <string name="attendance_date_label">Date</string>
+    <string name="present_label">Present</string>
+    <string name="absent_label">Absent</string>
+    <string name="save_attendance_button">Save attendance</string>
+
     <!-- Contract -->
     <string name="city_label">City</string>
     <string name="city_error">Please enter a city</string>

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/assistance/AssistanceRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/assistance/AssistanceRepository.kt
@@ -1,0 +1,20 @@
+package com.juanpablo0612.sigat.data.assistance
+
+import com.juanpablo0612.sigat.data.assistance.remote.AssistanceRemoteDataSource
+import com.juanpablo0612.sigat.domain.model.Assistance
+import com.juanpablo0612.sigat.domain.model.toDomain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AssistanceRepository(private val remoteDataSource: AssistanceRemoteDataSource) {
+    fun getAssistanceForProgramAndDate(programId: String, dateMillis: Long): Flow<List<Assistance>> {
+        return remoteDataSource.getAssistanceForProgramAndDate(programId, dateMillis).map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+
+    suspend fun setAttendance(programId: String, studentId: String, dateMillis: Long, present: Boolean) {
+        remoteDataSource.setAttendance(programId, studentId, dateMillis, present)
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/assistance/model/AssistanceModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/assistance/model/AssistanceModel.kt
@@ -1,0 +1,13 @@
+package com.juanpablo0612.sigat.data.assistance.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AssistanceModel(
+    val id: String = "",
+    val trainingProgramId: String = "",
+    val studentId: String = "",
+    val dateMillis: Long = 0L,
+    val present: Boolean = false
+)
+

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/assistance/remote/AssistanceRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/data/assistance/remote/AssistanceRemoteDataSource.kt
@@ -1,0 +1,31 @@
+package com.juanpablo0612.sigat.data.assistance.remote
+
+import com.juanpablo0612.sigat.data.assistance.model.AssistanceModel
+import dev.gitlive.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AssistanceRemoteDataSource(firestore: FirebaseFirestore) {
+    private val assistanceCollection = firestore.collection("assistance")
+
+    fun getAssistanceForProgramAndDate(programId: String, dateMillis: Long): Flow<List<AssistanceModel>> {
+        return assistanceCollection.where {
+            "trainingProgramId" equalTo programId
+            "dateMillis" equalTo dateMillis
+        }.snapshots.map { it.documents.map { doc -> doc.data() } }
+    }
+
+    suspend fun setAttendance(programId: String, studentId: String, dateMillis: Long, present: Boolean) {
+        val id = "${'$'}programId_${'$'}dateMillis_${'$'}studentId"
+        assistanceCollection.document(id).set(
+            AssistanceModel(
+                id = id,
+                trainingProgramId = programId,
+                studentId = studentId,
+                dateMillis = dateMillis,
+                present = present
+            )
+        )
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/di.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/di.kt
@@ -19,6 +19,8 @@ import com.juanpablo0612.sigat.data.training_programs.TrainingProgramsRepository
 import com.juanpablo0612.sigat.data.training_programs.remote.TrainingProgramsRemoteDataSource
 import com.juanpablo0612.sigat.data.users.UsersRepository
 import com.juanpablo0612.sigat.data.users.remote.UsersRemoteDataSource
+import com.juanpablo0612.sigat.data.assistance.AssistanceRepository
+import com.juanpablo0612.sigat.data.assistance.remote.AssistanceRemoteDataSource
 import com.juanpablo0612.sigat.domain.usecase.auth.ValidateEmailUseCase
 import com.juanpablo0612.sigat.domain.usecase.auth.ValidatePasswordUseCase
 import com.juanpablo0612.sigat.domain.usecase.auth.ValidateFirstNameUseCase
@@ -100,6 +102,8 @@ val dataModule = module {
     singleOf(::ContractsRepository)
     singleOf(::TrainingProgramsRemoteDataSource)
     singleOf(::TrainingProgramsRepository)
+    singleOf(::AssistanceRemoteDataSource)
+    singleOf(::AssistanceRepository)
 }
 
 fun initKoin(koinAppDeclaration: KoinAppDeclaration? = null) {

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/Assistance.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/Assistance.kt
@@ -1,0 +1,31 @@
+package com.juanpablo0612.sigat.domain.model
+
+import com.juanpablo0612.sigat.data.assistance.model.AssistanceModel
+
+/**
+ * Domain model representing attendance for a student in a training program.
+ */
+data class Assistance(
+    val id: String = "",
+    val trainingProgramId: String = "",
+    val studentId: String = "",
+    val dateMillis: Long = 0L,
+    val present: Boolean = false
+) {
+    fun toModel() = AssistanceModel(
+        id = id,
+        trainingProgramId = trainingProgramId,
+        studentId = studentId,
+        dateMillis = dateMillis,
+        present = present
+    )
+}
+
+fun AssistanceModel.toDomain() = Assistance(
+    id = id,
+    trainingProgramId = trainingProgramId,
+    studentId = studentId,
+    dateMillis = dateMillis,
+    present = present
+)
+


### PR DESCRIPTION
## Summary
- Introduce Firestore-backed assistance models, data source and repository
- Register attendance services in Koin and map to new Assistance domain model
- Extend training program detail view model, UI and strings to record and save student presence per date

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed544b7d48328bd79c7ad7f73dcc6