### PR TITLE
Add tabbed layout for training program detail

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.Clock
 
+enum class TrainingProgramDetailTab { Students, Attendance }
+
 class TrainingProgramDetailViewModel(
     private val repository: TrainingProgramsRepository,
     private val assistanceRepository: AssistanceRepository,
@@ -94,6 +96,10 @@ class TrainingProgramDetailViewModel(
                 uiState = uiState.copy(loadingAttendance = false)
             }
         }
+    }
+
+    fun onTabChange(tab: TrainingProgramDetailTab) {
+        uiState = uiState.copy(selectedTab = tab)
     }
     fun onNameChange(newName: String) {
         uiState = uiState.copy(name = newName, validName = newName.isNotBlank())
@@ -218,6 +224,7 @@ data class TrainingProgramDetailUiState(
     val students: List<String> = emptyList(),
     val newStudentId: String = "",
     val loading: Boolean = false,
+    val selectedTab: TrainingProgramDetailTab = TrainingProgramDetailTab.Students,
     val selectedDate: Long = Clock.System.now().toEpochMilliseconds(),
     val attendance: Map<String, Boolean> = emptyMap(),
     val loadingAttendance: Boolean = false,


### PR DESCRIPTION
## Summary
- add tab state and enum to training program detail view model
- display training program detail with Students and Attendance tabs
- separate student management and attendance into dedicated tab content

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee2c421a0832880aead876b34bc39