### PR TITLE
Load student details for training program detail

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.juanpablo0612.sigat.domain.model.User
 import com.juanpablo0612.sigat.ui.components.DatePickerTextField
 import com.juanpablo0612.sigat.ui.components.LoadingContent
 import com.juanpablo0612.sigat.ui.theme.Dimens
@@ -336,8 +337,8 @@ private fun StudentsTabContent(
 
         items(
             items = uiState.students,
-            key = { it }
-        ) { student ->
+            key = { it.uid }
+        ) { student: User ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -345,9 +346,12 @@ private fun StudentsTabContent(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = student, fontWeight = FontWeight.Bold)
+                Text(
+                    text = "${student.firstName} ${student.lastName}",
+                    fontWeight = FontWeight.Bold
+                )
                 IconButton(
-                    onClick = { viewModel.removeStudent(student) },
+                    onClick = { viewModel.removeStudent(student.uid) },
                     enabled = !uiState.loading
                 ) {
                     Icon(
@@ -409,10 +413,11 @@ private fun AttendanceTabContent(
             )
         }
 
+
         items(
             items = uiState.students,
-            key = { it + "_attendance" }
-        ) { student ->
+            key = { it.uid + "_attendance" }
+        ) { student: User ->
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -420,17 +425,21 @@ private fun AttendanceTabContent(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = student, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                Text(
+                    text = "${student.firstName} ${student.lastName}",
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f)
+                )
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = if (uiState.attendance[student] == true)
+                        text = if (uiState.attendance[student.uid] == true)
                             stringResource(Res.string.present_label)
                         else
-                            stringResource(Res.string.absent_label)
+                            stringResource(Res.string.absent_label),
                     )
                     Checkbox(
-                        checked = uiState.attendance[student] == true,
-                        onCheckedChange = { viewModel.toggleAttendance(student) },
+                        checked = uiState.attendance[student.uid] == true,
+                        onCheckedChange = { viewModel.toggleAttendance(student.uid) },
                         enabled = !uiState.loadingAttendance && !uiState.loading
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
@@ -7,9 +7,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.juanpablo0612.sigat.data.training_programs.TrainingProgramsRepository
 import com.juanpablo0612.sigat.data.assistance.AssistanceRepository
+import com.juanpablo0612.sigat.data.training_programs.TrainingProgramsRepository
+import com.juanpablo0612.sigat.data.users.UsersRepository
 import com.juanpablo0612.sigat.domain.model.TrainingProgram
+import com.juanpablo0612.sigat.domain.model.User
 import com.juanpablo0612.sigat.ui.navigation.Screen
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
@@ -20,6 +22,7 @@ enum class TrainingProgramDetailTab { Students, Attendance }
 class TrainingProgramDetailViewModel(
     private val repository: TrainingProgramsRepository,
     private val assistanceRepository: AssistanceRepository,
+    private val usersRepository: UsersRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     var uiState by mutableStateOf(TrainingProgramDetailUiState())
@@ -37,6 +40,7 @@ class TrainingProgramDetailViewModel(
             try {
                 val program = repository.getTrainingProgram(id)
                 if (program != null) {
+                    val students = usersRepository.getUsersByIds(program.students).getOrThrow()
                     uiState = uiState.copy(
                         id = program.id,
                         name = program.name,
@@ -45,7 +49,8 @@ class TrainingProgramDetailViewModel(
                         endDate = program.endDate,
                         schedule = program.schedule,
                         teacherUserId = program.teacherUserId,
-                        students = program.students
+                        studentIds = program.students,
+                        students = students
                     )
                     loadAttendance(uiState.selectedDate)
                 }
@@ -154,7 +159,7 @@ class TrainingProgramDetailViewModel(
                         endDate = uiState.endDate!!,
                         schedule = uiState.schedule,
                         teacherUserId = uiState.teacherUserId,
-                        students = uiState.students
+                        students = uiState.studentIds
                     )
                 )
             } catch (e: Exception) {
@@ -221,7 +226,8 @@ data class TrainingProgramDetailUiState(
     val schedule: String = "",
     val validSchedule: Boolean = true,
     val teacherUserId: String = "",
-    val students: List<String> = emptyList(),
+    val studentIds: List<String> = emptyList(),
+    val students: List<User> = emptyList(),
     val newStudentId: String = "",
     val loading: Boolean = false,
     val selectedTab: TrainingProgramDetailTab = TrainingProgramDetailTab.Students,


### PR DESCRIPTION
## Summary
- inject `UsersRepository` into `TrainingProgramDetailViewModel`
- fetch and keep full `User` objects alongside student ids in UI state
- show student names and handle attendance using user ids

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c087b1390c832896e6cdec7fd99ae6