### PR TITLE
Add User fullName extension and use in ManageRolesScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/User.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/User.kt
@@ -22,3 +22,6 @@ data class User(
         role = role.toModel()
     )
 }
+
+val User.fullName: String
+    get() = "$firstName $lastName"

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/admin/manage_roles/ManageRolesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/admin/manage_roles/ManageRolesScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.domain.model.Role
 import com.juanpablo0612.sigat.domain.model.User
+import com.juanpablo0612.sigat.domain.model.fullName
 import com.juanpablo0612.sigat.ui.components.ErrorCard
 import com.juanpablo0612.sigat.ui.components.LoadingContent
 import com.juanpablo0612.sigat.ui.theme.Dimens
@@ -129,7 +130,7 @@ private fun UserRoleCard(
                 }
             }
             Text(
-                text = "${user.firstName} ${user.lastName}",
+                text = user.fullName,
                 style = MaterialTheme.typography.titleMedium
             )
             Text(


### PR DESCRIPTION
## Summary
- add `User.fullName` extension for convenience
- use `user.fullName` in `ManageRolesScreen` instead of manual name concatenation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c087bbedd08328bcfa2939af701873