### PR TITLE
Handle user objects in training program detail

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/User.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/domain/model/User.kt
@@ -22,3 +22,6 @@ data class User(
         role = role.toModel()
     )
 }
+
+val User.fullName: String
+    get() = "$firstName $lastName".trim()

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import com.juanpablo0612.sigat.ui.components.DatePickerTextField
 import com.juanpablo0612.sigat.ui.components.LoadingContent
 import com.juanpablo0612.sigat.ui.theme.Dimens
+import com.juanpablo0612.sigat.domain.model.fullName
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import sigat.composeapp.generated.resources.Res
@@ -336,7 +337,7 @@ private fun StudentsTabContent(
 
         items(
             items = uiState.students,
-            key = { it }
+            key = { it.uid }
         ) { student ->
             Row(
                 modifier = Modifier
@@ -345,9 +346,9 @@ private fun StudentsTabContent(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = student, fontWeight = FontWeight.Bold)
+                Text(text = student.fullName, fontWeight = FontWeight.Bold)
                 IconButton(
-                    onClick = { viewModel.removeStudent(student) },
+                    onClick = { viewModel.removeStudent(student.uid) },
                     enabled = !uiState.loading
                 ) {
                     Icon(
@@ -411,7 +412,7 @@ private fun AttendanceTabContent(
 
         items(
             items = uiState.students,
-            key = { it + "_attendance" }
+            key = { it.uid + "_attendance" }
         ) { student ->
             Row(
                 modifier = Modifier
@@ -420,17 +421,17 @@ private fun AttendanceTabContent(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(text = student, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                Text(text = student.fullName, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = if (uiState.attendance[student] == true)
+                        text = if (uiState.attendance[student.uid] == true)
                             stringResource(Res.string.present_label)
                         else
                             stringResource(Res.string.absent_label)
                     )
                     Checkbox(
-                        checked = uiState.attendance[student] == true,
-                        onCheckedChange = { viewModel.toggleAttendance(student) },
+                        checked = uiState.attendance[student.uid] == true,
+                        onCheckedChange = { viewModel.toggleAttendance(student.uid) },
                         enabled = !uiState.loadingAttendance && !uiState.loading
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/juanpablo0612/sigat/ui/training_programs/detail/TrainingProgramDetailViewModel.kt
@@ -9,7 +9,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.juanpablo0612.sigat.data.training_programs.TrainingProgramsRepository
 import com.juanpablo0612.sigat.data.assistance.AssistanceRepository
+import com.juanpablo0612.sigat.data.users.UsersRepository
 import com.juanpablo0612.sigat.domain.model.TrainingProgram
+import com.juanpablo0612.sigat.domain.model.User
 import com.juanpablo0612.sigat.ui.navigation.Screen
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
@@ -20,6 +22,7 @@ enum class TrainingProgramDetailTab { Students, Attendance }
 class TrainingProgramDetailViewModel(
     private val repository: TrainingProgramsRepository,
     private val assistanceRepository: AssistanceRepository,
+    private val usersRepository: UsersRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     var uiState by mutableStateOf(TrainingProgramDetailUiState())
@@ -37,6 +40,9 @@ class TrainingProgramDetailViewModel(
             try {
                 val program = repository.getTrainingProgram(id)
                 if (program != null) {
+                    val students = usersRepository
+                        .getUsersByIds(program.students)
+                        .getOrElse { emptyList() }
                     uiState = uiState.copy(
                         id = program.id,
                         name = program.name,
@@ -45,7 +51,8 @@ class TrainingProgramDetailViewModel(
                         endDate = program.endDate,
                         schedule = program.schedule,
                         teacherUserId = program.teacherUserId,
-                        students = program.students
+                        studentIds = program.students,
+                        students = students
                     )
                     loadAttendance(uiState.selectedDate)
                 }
@@ -154,7 +161,7 @@ class TrainingProgramDetailViewModel(
                         endDate = uiState.endDate!!,
                         schedule = uiState.schedule,
                         teacherUserId = uiState.teacherUserId,
-                        students = uiState.students
+                        students = uiState.studentIds
                     )
                 )
             } catch (e: Exception) {
@@ -221,7 +228,8 @@ data class TrainingProgramDetailUiState(
     val schedule: String = "",
     val validSchedule: Boolean = true,
     val teacherUserId: String = "",
-    val students: List<String> = emptyList(),
+    val studentIds: List<String> = emptyList(),
+    val students: List<User> = emptyList(),
     val newStudentId: String = "",
     val loading: Boolean = false,
     val selectedTab: TrainingProgramDetailTab = TrainingProgramDetailTab.Students,


### PR DESCRIPTION
## Summary
- Track student IDs separately from loaded User objects in training program detail state
- Display each student's full name and map attendance by user ID
- Add User.fullName extension for easier display

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bc70fc548328a093fa7d0a14c5e5